### PR TITLE
Remove APG and X509Tools

### DIFF
--- a/worksWithK9.md
+++ b/worksWithK9.md
@@ -13,8 +13,6 @@ here are some of the more useful-looking ones.
 Security / Encryption:
 
 * [OpenKeychain](https://www.openkeychain.org/) - End-to-end email encryption with the OpenPGP standard
-* [APG](https://play.google.com/store/apps/details?id=org.thialfihar.android.apg) - Predecessor of OpenKeychain (not actively maintained)
-* [X509Tools](https://play.google.com/store/apps/details?id=at.rundquadrat.android.x509tools)
 
 Widgets:
 


### PR DESCRIPTION
APG is no longer supported and maintained and X509Tools hasn't received an update for 3 years. Bad signs for a security app.