### PR TITLE
Consistently make development header first

### DIFF
--- a/documentation/development/imapExtensions.md
+++ b/documentation/development/imapExtensions.md
@@ -4,9 +4,9 @@ nav_hide: true
 layout: default
 ---
 
-{% include documentation-header.html %}
-
 {% include development-header.html %}
+
+{% include documentation-header.html %}
 
 # IMAP Capabilities &amp; Commands Extensions
 

--- a/documentation/development/intents.md
+++ b/documentation/development/intents.md
@@ -4,9 +4,9 @@ nav_hide: true
 layout: default
 ---
 
-{% include documentation-header.html %}
-
 {% include development-header.html %}
+
+{% include documentation-header.html %}
 
 # Intents
 

--- a/documentation/development/rfcs.md
+++ b/documentation/development/rfcs.md
@@ -4,9 +4,9 @@ nav_hide: true
 layout: default
 ---
 
-{% include documentation-header.html %}
-
 {% include development-header.html %}
+
+{% include documentation-header.html %}
 
 # RFCs
 


### PR DESCRIPTION
Found this minor inconsistency while browsing the development pages.