### PR TITLE
Add short link to 'Push Info' page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ plugins:
   - jekyll-paginate
   - jekyll-compose
   - jekyll-feed
+  - jekyll-redirect-from
 
 collections:
   documentation:

--- a/go/push-info.md
+++ b/go/push-info.md
@@ -1,0 +1,4 @@
+---
+title: Push Info
+redirect_to: https://forum.k9mail.app/t/how-to-configure-push/1102
+---


### PR DESCRIPTION
This is so the app can reference https://k9mail.app/go/push-info and we can later change the redirect destination without having to update the app.